### PR TITLE
The dataframe now contains the DQ values for the interested pixels  f…

### DIFF
--- a/Pixel_based/Pers_in_visit_rampcheck.ipynb
+++ b/Pixel_based/Pers_in_visit_rampcheck.ipynb
@@ -369,7 +369,9 @@
     "            imtyps[istim],\n",
     "            imtyps[istim+j],\n",
     "            flts_dqs[istim,nz1,nz0],\n",
-    "            ima_dqs[ioff+k,nz1,nz0]\n",
+    "            ima_dqs[ioff+k,nz1,nz0],\n",
+    "            ima_scis[ioff+k,nz1,nz0],\n",
+    "            te\n",
     "           ]\n"
    ]
   },
@@ -720,7 +722,7 @@
     "gc.collect()\n",
     "\n",
     "df = pd.DataFrame()\n",
-    "cols = ['Stim','EXPTIME_stim','xpix','ypix','tfromstim','deltat','Read index','NSAMP','meancurr','stdvcurr','Ind_stim','Ind_pers','Stim_type','Pers_type','DQ_stim','DQ_pers']\n",
+    "cols = ['Stim','EXPTIME_stim','xpix','ypix','tfromstim','deltat','Read index','NSAMP','meancurr','stdvcurr','Ind_stim','Ind_pers','Stim_type','Pers_type','DQ_stim','DQ_pers','IMA_val','samptime']\n",
     "\n",
     "mypool = Pool(numcores)\n",
     "\n",
@@ -800,7 +802,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "#Make sure that the data types are set to more space-efficient ones\n",
@@ -808,7 +812,7 @@
     "df2['Ind_pers'] = df2['Ind_pers'].astype(np.uint8)\n",
     "df2['Read index'] = df2['Read index'].astype(np.uint8)\n",
     "df2['NSAMP'] = df2['NSAMP'].astype(np.uint8)\n",
-    "df2[['tfromstim','deltat','meancurr','stdvcurr']] = df2[['tfromstim','deltat','meancurr','stdvcurr']].astype(np.float32)\n",
+    "df2[['tfromstim','deltat','meancurr','stdvcurr','IMA_val','samptime']] = df2[['tfromstim','deltat','meancurr','stdvcurr','IMA_val','samptime']].astype(np.float32)\n",
     "df2['Uniq_multiindex'] = df2['Uniq_multiindex'].astype(np.uint32)\n"
    ]
   },
@@ -842,8 +846,83 @@
     "df_values['Pers_type']       = df2['Pers_type'].values \n",
     "df_values['DQ_pers']         = df2['DQ_pers'].values \n",
     "df_values['Uniq_multiindex'] = df2['Uniq_multiindex'].values \n",
+    "df_values['IMA_val']         = df2['IMA_val'].values \n",
+    "df_values['samptime']        = df2['samptime'].values \n",
+    "\n",
     "\n",
     "df_values.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "#df_values[(df_values['DQ_pers'].values & 8192) == 8192]\n",
+    "BM = (df_values['Uniq_multiindex'].values  == 577)\n",
+    "#BM = (df_values['Uniq_multiindex'].values  == 0)\n",
+    "\n",
+    "#BM = (df_values['Uniq_multiindex'].values  >= 0)\n",
+    "\n",
+    "\n",
+    "dfP = df_values[BM].copy()\n",
+    "dfP\n",
+    "#dfP[dfP['Read index'] == 12]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = plt.figure()\n",
+    "ax1 = plt.subplot(3,1,1)\n",
+    "ax1.scatter(dfP['tfromstim'],dfP['meancurr'],c=dfP['Ind_pers'].values/len(vsflts),cmap='prism')\n",
+    "ax2 = ax1.twinx()\n",
+    "ax2.scatter(dfP['tfromstim'],dfP['DQ_pers'],c=dfP['Ind_pers'].values/len(vsflts),cmap='prism',marker='x')\n",
+    "\n",
+    "ax3 = plt.subplot(3,1,2)\n",
+    "ax3.scatter(dfP['tfromstim'],dfP['IMA_val'],c=dfP['Ind_pers'].values/len(vsflts),cmap='prism')\n",
+    "ax4 = ax3.twinx()\n",
+    "ax4.scatter(dfP['tfromstim'],dfP['DQ_pers'],c=dfP['Ind_pers'].values/len(vsflts),cmap='prism',marker='x')\n",
+    "\n",
+    "ax5 = plt.subplot(3,1,3)\n",
+    "ax5.scatter(dfP['tfromstim'],dfP['IMA_val']*dfP['samptime'],c=dfP['Ind_pers'].values/len(vsflts),cmap='prism')\n",
+    "ax6 = ax5.twinx()\n",
+    "ax6.scatter(dfP['tfromstim'],dfP['DQ_pers'],c=dfP['Ind_pers'].values/len(vsflts),cmap='prism',marker='x')\n",
+    "\n",
+    "yd, yu = ax1.get_ylim()\n",
+    "ax1.set_ylim(yd-5,yu+5)\n",
+    "yd, yu = ax3.get_ylim()\n",
+    "ax3.set_ylim(yd-5,yu+5)\n",
+    "yd, yu = ax5.get_ylim()\n",
+    "ax5.set_ylim(yd-5,yu+5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "#df.to_hdf(sdir+'Test_nocompress_noMulti_pytable_DF.h5', 'Visit'+'{:0>2}'.format(str(visit_index+1)), mode='a',format = 't')\n",
+    "#df['xpix'] =df['xpix'].astype(int)\n",
+    "#df['ypix'] =df['ypix'].astype(int)\n",
+    "#df['Read index'] =df['Read index'].astype(int)\n",
+    "#df['NSAMP'] =df['NSAMP'].astype(int)\n",
+    "#df['Ind_stim'] =df['Ind_stim'].astype(int)\n",
+    "#df['Ind_pers'] =df['Ind_pers'].astype(int)\n",
+    "\n",
+    "#df2 = df.set_index(['xpix', 'ypix','NSAMP','Ind_stim','Stim','EXPTIME_stim','Stim_type','Pers_type','Ind_pers',df.index])\n",
+    "#df2\n",
+    "#df2.to_hdf(sdir+'Test_nocompress_pytable_DF.h5', 'Visit'+'{:0>2}'.format(str(visit_index+1)), mode='a',format = 'f')\n",
+    "#df.to_hdf(sdir+'DF_all.h5', 'Visit'+'{:0>2}'.format(str(visit_index+1)), mode='a',format = 't')\n"
    ]
   },
   {


### PR DESCRIPTION
…or both the flt stimulus exposure

AND the persistence exposures, i.e. the individual IMA reads.
While developing I have written a couple of plotting routines that are in the new file Pers_in_visit_rampcheck, just in case I need that in the future

Also, a bug in the get_superdark_planes routine has been fixed. The routine now checks the DARKS BUNIT and always return images in e-/s  by subtracting the zero-th read and dividing by the samptime, just like an IMA file